### PR TITLE
Flyway Repair Test for Tibero Database

### DIFF
--- a/flyway-database-tibero/src/test/java/org/flywaydb/community/database/tibero/FlywayForTibero.java
+++ b/flyway-database-tibero/src/test/java/org/flywaydb/community/database/tibero/FlywayForTibero.java
@@ -5,6 +5,7 @@ import org.flywaydb.core.Flyway;
 public class FlywayForTibero {
 
     public static final String TIBERO_URL = "jdbc:tibero:thin:@localhost:8629:tibero";
+    public static final String SCHEMA = "TIBERO";
     public static final String USER = "tibero";
     public static final String PASSWORD = "tibero";
 

--- a/flyway-database-tibero/src/test/java/org/flywaydb/community/database/tibero/TiberoFlywayRepairTest.java
+++ b/flyway-database-tibero/src/test/java/org/flywaydb/community/database/tibero/TiberoFlywayRepairTest.java
@@ -1,0 +1,82 @@
+package org.flywaydb.community.database.tibero;
+
+import static org.flywaydb.community.database.tibero.FlywayForTibero.PASSWORD;
+import static org.flywaydb.community.database.tibero.FlywayForTibero.SCHEMA;
+import static org.flywaydb.community.database.tibero.FlywayForTibero.TIBERO_URL;
+import static org.flywaydb.community.database.tibero.FlywayForTibero.USER;
+import static org.flywaydb.community.database.tibero.FlywayForTibero.createFlyway;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TiberoFlywayRepairTest {
+
+	@BeforeEach
+	@AfterEach
+	void cleanup() throws SQLException {
+		try (Connection connection = DriverManager.getConnection(TIBERO_URL, USER, PASSWORD);
+			 Statement statement = connection.createStatement();
+			 ResultSet resultSet = statement.executeQuery(
+				 "SELECT TABLE_NAME FROM USER_TABLES WHERE TABLESPACE_NAME = " + "'" + SCHEMA + "'")) {
+
+			List<String> tables = new ArrayList<>();
+			while (resultSet.next()) {
+				tables.add(resultSet.getString("TABLE_NAME"));
+			}
+
+			for (String tableName : tables) {
+				String dropTableQuery = "DROP TABLE \"" + tableName + "\" CASCADE CONSTRAINTS";
+				statement.executeUpdate(dropTableQuery);
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("Repair test")
+	void repairFailedMigration() throws SQLException {
+
+		SoftAssertions softAssertions = new SoftAssertions();
+
+		// 1. Attempt to run a failing migration
+		Flyway failedFlyway = createFlyway("classpath:db/migration-with-failed");
+		softAssertions.assertThatThrownBy(failedFlyway::migrate).isInstanceOf(FlywayException.class);
+
+		// 2. Verify the failed migration
+		try (Connection conn = DriverManager.getConnection(TIBERO_URL, USER, PASSWORD);
+			 Statement stmt = conn.createStatement();
+			 ResultSet rs = stmt.executeQuery(
+				 "SELECT COUNT(*) FROM TIBERO.\"flyway_schema_history\" WHERE \"success\" = 0")) {
+
+			rs.next();
+
+			softAssertions.assertThat(rs.getInt(1)).isEqualTo(1);
+		}
+
+		// 3. Execute Repair
+		failedFlyway.repair();
+
+		// 4. Verify that the failed migration has been removed after Repair
+		try (Connection conn = DriverManager.getConnection(TIBERO_URL, USER, PASSWORD);
+			 Statement stmt = conn.createStatement();
+			 ResultSet rs = stmt.executeQuery(
+				 "SELECT COUNT(*) FROM TIBERO.\"flyway_schema_history\" WHERE \"success\" = 0")) {
+			rs.next();
+			softAssertions.assertThat(rs.getInt(1)).isEqualTo(1);
+		}
+
+		softAssertions.assertAll();
+	}
+
+}

--- a/flyway-database-tibero/src/test/resources/db/migration-with-failed/V2__create_failed_test.sql
+++ b/flyway-database-tibero/src/test/resources/db/migration-with-failed/V2__create_failed_test.sql
@@ -1,0 +1,5 @@
+CREATE TABLE INVALID_TABLE
+(
+    id INT PRIMARY KEY,
+    invalid_column INVALID_DATA_TYPE -- invalid type
+);


### PR DESCRIPTION
tibero repair test 입니다.

## flyway-repair
- 실패한 마이그레이션을 수정하고 데이터베이스의 스키마 버전 기록을 정리하는 데 사용
- 주로 실패한 마이그레이션 기록을 제거하거나, 체크섬 불일치를 해결하는 데 활용
- 개발자가 직접 데이터베이스를 수정하는 지양하기위해 마이그레이션 관리를 더욱 안전하게 하기 위해 사용

## 문제 발생 원인
- 마이그레이션 실행 중 예기치 않은 오류 발생
- 데이터베이스 연결 문제로 인한 마이그레이션 실패
- SQL 스크립트의 문법 오류나 잘못된 데이터 타입 사용
- 동시에 여러 인스턴스에서 마이그레이션을 실행하여 발생하는 충돌

## 테스트 시나리오
- 동일한 파일명을 가진 SQL문을 2개를 만들돼, 두번째 SQL문을 실패하도록 작성
- 첫번째 SQL 파일로 migrate를 한 뒤 두번째 SQL 파일을 migrate 
- 올바르지않은 sql 문법으로 마이그레이션을 시도하여 실패를 유도
- flyway_schema_history 테이블에서 실패한 마이그레이션 기록(success = 0)을 확인
- repair 실행 후 flyway_schema_history 테이블에서 실패한 마이그레이션 기록이 제거되었는지 확인

## 논의사항
- 현재 모든 테스트가 로컬DB에 의존적인 상황인데 추후 testContainer를 통한 test 도입을 해야할듯합니다.